### PR TITLE
Update README and change chitanka production repo branch to master again

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 # Как да използваме?
 
 ```console
-git clone https://github.com/basecat/chitanka-docker chitanka
-cd chitanka
+$ git clone https://github.com/basecat/chitanka-docker chitanka
+$ cd chitanka
 ... създайте docker-compose.yml
 docker-compose up -d
 ```
@@ -44,6 +44,7 @@ services:
   db:
     image: mariadb:10.5
     restart: always
+    command: --collation-server=utf8mb4_unicode_ci --character-set-server=utf8mb4 --skip-character-set-client-handshake
     volumes:
       - db:/var/lib/mysql
     environment:
@@ -118,6 +119,7 @@ volumes:
   db:
     image: mariadb:10.5
     restart: always
+    command: --collation-server=utf8mb4_unicode_ci --character-set-server=utf8mb4 --skip-character-set-client-handshake
     volumes:
       - db:/var/lib/mysql
     environment:

--- a/chitanka/Dockerfile
+++ b/chitanka/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-fpm-bullseye
-LABEL version="0.4"
+LABEL version="1.1"
 LABEL description="chitanka.info on Docker"
 
 RUN set -ex; \
@@ -54,7 +54,7 @@ RUN set -ex; \
 	  git \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-    git clone --depth 1 --branch chitanka.info https://github.com/chitanka/chitanka-production.git /var/www/chitanka; \
+    git clone --depth 1 --branch master https://github.com/chitanka/chitanka-production.git /var/www/chitanka; \
     chown -R www-data:www-data /var/www/chitanka; \
     cd /var/www/chitanka && chmod -R 777 var/cache var/log var/spool web/cache; \
     curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && \


### PR DESCRIPTION
## Description
- Update README.me to provide an example how to set the [MariaDB default character set to UTF-8](https://github.com/basekat/chitanka-docker/issues/1#issuecomment-1468394336) https://github.com/basekat/chitanka-docker/issues/1#issuecomment-1468394336
- Use master branch when cloning from chitanka-production repo